### PR TITLE
Add erlang.mk to build tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ A curated list of amazingly awesome Erlang libraries, resources and shiny thing 
 ## Build Tools
 *Project build and automation tools.*
 
+* [erlang.mk](https://github.com/ninenines/erlang.mk) - A build tool for Erlang using Makefiles. See more at [erlang.mk](https://erlang.mk/).
 * [rebar](https://github.com/rebar/rebar) - Erlang build tool that makes it easy to compile and test Erlang applications, port drivers and releases.
 * [rebar3](https://github.com/rebar/rebar3) - A build tool for Erlang which can manage Erlang packages from [Hex.pm](https://hex.pm/). See more at [rebar3.org](https://www.rebar3.org/)
 * [sync](https://github.com/rustyio/sync) - On-the-fly recompiling for Erlang.


### PR DESCRIPTION
How come you missed out on erlang.mk :) I use it for all my projects instead of rebar.